### PR TITLE
Fix ember-cli/lib/ext/promise deprecation (sans Yarn)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 'use strict';
 
 
-var Promise   = require('ember-cli/lib/ext/promise');
+var Promise          = require('rsvp').Promise;
 var DeployPluginBase = require('ember-cli-deploy-plugin');
-var cpr = require('cpr');
-var SilentError         = require('silent-error');
+var cpr              = require('cpr');
+var SilentError      = require('silent-error');
 
 module.exports = {
   name: 'ember-cli-deploy-cp',

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.13.5",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [
@@ -44,6 +44,7 @@
     "cpr": "1.0.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "rsvp": "^3.5.0",
     "silent-error": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This is @xomaczar's fix (#10), sans the `yarn.lock` addition.