### PR TITLE
ember-cli-babel should not a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.4.0",
+    "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.9",
@@ -42,7 +43,6 @@
   ],
   "dependencies": {
     "cpr": "1.0.0",
-    "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.0",
     "rsvp": "^3.5.0",
     "silent-error": "^1.0.0"


### PR DESCRIPTION
Only addons that ship runtime code should depend on ember-cli-babel.

babel5 is deprecated and the error message was quite annoying.